### PR TITLE
Added notice regarding breaking of ContentEditable behavior

### DIFF
--- a/ce/developer/clientapi/reference/GetGlobalContext-ClientGlobalContext.js.aspx.md
+++ b/ce/developer/clientapi/reference/GetGlobalContext-ClientGlobalContext.js.aspx.md
@@ -53,6 +53,20 @@ You must include a reference to the **ClientGlobalContext.js.aspx** page located
 
 The **ClientGlobalContext.js.aspx** page will include some global event handlers. These event handlers will cancel the [onselectstart](https://developer.mozilla.org/en-US/docs/Web/Events/selectstart), [contextmenu](https://developer.mozilla.org/en-US/docs/Web/Events/contextmenu), and [ondragstart](https://developer.mozilla.org/en-US/docs/Web/Events/dragstart) events. 
 
+> [!NOTE]
+> HTML5 introduced a new feature "Content Editable", which allows to edit the content of an element just by clicking on it and typing.
+> Loading ClientGlobalContext onto your page may lead to issues when using HTML5 ContentEditable elements, where you can't properly select and edit the content. This is due to the context registering to global events, as described above.
+> Example: 
+> <html>
+>   <body>
+>     <!-- Uncomment below loading of ClientGlobalContext, the div content will not be editable anymore
+>       <script src="ClientGlobalContext.js.aspx" type="text/javascript"></script>
+>     -->
+>     <div contenteditable />
+>   </body>
+> </html>
+
+
 ### Related topics
 
 [Xrm.Utility.getGlobalContext](Xrm-Utility/getGlobalContext.md)


### PR DESCRIPTION
Hey there,

I had a pretty long debugging session with a CRM web resource that used HTML5 content editable elements.
As it turns out, adding ClientGlobalContext to a page causes interferences with content editable elements.

I added a notice with an example, as I think that this is an important thing to know.

Kind Regards,
Florian